### PR TITLE
Zoom and Street View controls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,9 @@ export class Map extends React.Component {
           disableDoubleClickZoom: this.props.disableDoubleClickZoom,
           noClear: this.props.noClear,
           styles: this.props.styles,
-          gestureHandling: this.props.gestureHandling
+          gestureHandling: this.props.gestureHandling,
+          streetViewControlOptions:this.props.streetViewControlOptions,
+          zoomControlOptions:this.props.zoomControlOptions
         }
       );
 
@@ -290,7 +292,9 @@ Map.propTypes = {
   noClear: PropTypes.bool,
   styles: PropTypes.array,
   gestureHandling: PropTypes.string,
-  bounds: PropTypes.object
+  bounds: PropTypes.object,
+  streetViewControlOptions:PropTypes.object,
+  zoomControlOptions:PropTypes.object
 };
 
 evtNames.forEach(e => (Map.propTypes[camelize(e)] = PropTypes.func));


### PR DESCRIPTION
Added the capability to pass the "streetViewControlOptions" and "zoomControlOptions" from the google API to change the position of these controls on the map using the predefined "ControlPosition".